### PR TITLE
Maximum glob depth prediction

### DIFF
--- a/src/walk.rs
+++ b/src/walk.rs
@@ -883,7 +883,14 @@ pub fn walk<'g>(
     behavior: impl Into<WalkBehavior>,
 ) -> Walk<'g> {
     let directory = directory.as_ref();
-    let WalkBehavior { depth, link } = behavior.into();
+    let WalkBehavior { mut depth, link } = behavior.into();
+
+    if depth == usize::MAX {
+        if let Some(max_depth) = glob.try_get_max_depth() {
+            depth = max_depth;
+        }
+    }
+
     // The directory tree is traversed from `root`, which may include an
     // invariant prefix from the glob pattern. `Walk` patterns are only applied
     // to path components following this prefix in `root`.


### PR DESCRIPTION
An attempt to predict how deep a glob will go. This should only come into effect when the user doesn't provide an explicit depth (in the current state, when usize::MAX is passed to WalkBehavior).

The current heuristic is simple: It walks through every token, and if it's a wildcard or repetition, it bails out. Otherwise, it simply increases the maximum depth by 1 for each separator found.

I may have missed something, and I certainly don't want to break anything. I also haven't tried it in a hyper diverse set of globs; just a healthy few:
```
.
*
*/*
*/*/*
**/*
**

/src
/src/*
/src/**
src/*
src/**
src/**/*.rs
src/**/*.rs
{src/**/token,bruh}/*.rs
<a*/:0,>
<[!.]*/>[!.]*
```

It is very very faster when ran on big directories for globs that can have this optimization applied. But I am not super confident that no globs will slip by. And I am also not confident that it won't over-predict; in fact, it definitely will for globs like `a/{b/b,c/c,d/d}/e`. This is solvable if I simply account for nested structures via some recursion in the `try_get_max_depth` function, but I'd rather get some feedback before committing too much to the implementation.

Thoughts?