### PR TITLE
fix: prevent negated patterns from traversing directory boundaries

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -250,7 +250,13 @@ fn encode<'t, A, T>(
                             },
                         }
                     }
-                    pattern.push_str(nsepexpr!("&&{0}]"));
+                    if class.is_negated() {
+                        pattern.push_str(SEPARATOR_CLASS_EXPRESSION);
+                    }
+                    else {
+                        pattern.push_str(nsepexpr!("&&{0}"));
+                    }
+                    pattern.push_str("]");
                     // Compile the character class sub-expression. This may fail
                     // if the subtraction of the separator pattern yields an
                     // empty character class (meaning that the glob expression

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -235,28 +235,33 @@ fn encode<'t, A, T>(
             },
             (_, Class(class)) => {
                 grouping.push_with(pattern, || {
+                    use crate::token::Class as ClassToken;
+
+                    fn encode_class_archetypes(class: &ClassToken, pattern: &mut String) {
+                        for archetype in class.archetypes() {
+                            match archetype {
+                                Character(literal) => pattern.push_str(&literal.escaped()),
+                                Range(left, right) => {
+                                    pattern.push_str(&left.escaped());
+                                    pattern.push('-');
+                                    pattern.push_str(&right.escaped());
+                                },
+                            }
+                        }
+                    }
+
                     let mut pattern = String::new();
                     pattern.push('[');
                     if class.is_negated() {
                         pattern.push('^');
-                    }
-                    for archetype in class.archetypes() {
-                        match archetype {
-                            Character(literal) => pattern.push_str(&literal.escaped()),
-                            Range(left, right) => {
-                                pattern.push_str(&left.escaped());
-                                pattern.push('-');
-                                pattern.push_str(&right.escaped());
-                            },
-                        }
-                    }
-                    if class.is_negated() {
+                        encode_class_archetypes(class, &mut pattern);
                         pattern.push_str(SEPARATOR_CLASS_EXPRESSION);
                     }
                     else {
+                        encode_class_archetypes(class, &mut pattern);
                         pattern.push_str(nsepexpr!("&&{0}"));
                     }
-                    pattern.push_str("]");
+                    pattern.push(']');
                     // Compile the character class sub-expression. This may fail
                     // if the subtraction of the separator pattern yields an
                     // empty character class (meaning that the glob expression

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1347,6 +1347,20 @@ mod tests {
     }
 
     #[test]
+    fn negative_match_does_not_traverse_folders() {
+        let glob = Glob::new("a[!b]c").unwrap();
+        assert!(glob.is_match(Path::new("adc")));
+        assert!(!glob.is_match(Path::new("a/c")));
+    }
+
+    #[test]
+    fn negative_match_does_not_traverse_folders_2() {
+        let glob = Glob::new("a[!b-z]c").unwrap();
+        assert!(glob.is_match(Path::new("aac")));
+        assert!(!glob.is_match(Path::new("a/c")));
+    }
+
+    #[test]
     fn build_glob_with_alternative_tokens() {
         Glob::new("a/{x?z,y$}b*").unwrap();
         Glob::new("a/{???,x$y,frob}b*").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1347,20 +1347,6 @@ mod tests {
     }
 
     #[test]
-    fn negative_match_does_not_traverse_folders() {
-        let glob = Glob::new("a[!b]c").unwrap();
-        assert!(glob.is_match(Path::new("adc")));
-        assert!(!glob.is_match(Path::new("a/c")));
-    }
-
-    #[test]
-    fn negative_match_does_not_traverse_folders_2() {
-        let glob = Glob::new("a[!b-z]c").unwrap();
-        assert!(glob.is_match(Path::new("aac")));
-        assert!(!glob.is_match(Path::new("a/c")));
-    }
-
-    #[test]
     fn build_glob_with_alternative_tokens() {
         Glob::new("a/{x?z,y$}b*").unwrap();
         Glob::new("a/{???,x$y,frob}b*").unwrap();
@@ -1768,6 +1754,26 @@ mod tests {
         // effectively matches nothing.
         let glob = Glob::new("a[/]b").unwrap();
 
+        assert!(!glob.is_match(Path::new("a/b")));
+    }
+
+    #[test]
+    fn match_glob_with_negated_class_tokens() {
+        let glob = Glob::new("a[!b]c").unwrap();
+
+        assert!(glob.is_match(Path::new("a-c")));
+        assert!(glob.is_match(Path::new("axc")));
+
+        assert!(!glob.is_match(Path::new("abc")));
+        assert!(!glob.is_match(Path::new("a/c")));
+
+        let glob = Glob::new("a[!0-4]b").unwrap();
+
+        assert!(glob.is_match(Path::new("a9b")));
+        assert!(glob.is_match(Path::new("axb")));
+
+        assert!(!glob.is_match(Path::new("a0b")));
+        assert!(!glob.is_match(Path::new("a4b")));
         assert!(!glob.is_match(Path::new("a/b")));
     }
 


### PR DESCRIPTION
Closes #40 by not pushing &&[^/] if we are already in a negation pattern, and just pushing the separator instead.